### PR TITLE
make compatible with makefiles that have no extension

### DIFF
--- a/autoload/skeletons.vim
+++ b/autoload/skeletons.vim
@@ -107,7 +107,7 @@ function! s:skeletons.insertSkeleton()
         call self.registerSkeletons()
     endif
     " grab file extension of current new file
-    let fileExt = expand('%:e') ? expand('%:e') : expand('%:t')
+    let fileExt = empty(expand('%:e')) ? expand('%:r') : expand('%:e')
     let skeletonFile = self.chooseSkeleton(fileExt)
     if len(skeletonFile)>0 && filereadable(skeletonFile)
         let l:snippet = join(readfile(skeletonFile), "\n")

--- a/autoload/skeletons.vim
+++ b/autoload/skeletons.vim
@@ -107,7 +107,7 @@ function! s:skeletons.insertSkeleton()
         call self.registerSkeletons()
     endif
     " grab file extension of current new file
-    let fileExt = expand('%:e')
+    let fileExt = expand('%:e') ? expand('%:e') : expand('%:t')
     let skeletonFile = self.chooseSkeleton(fileExt)
     if len(skeletonFile)>0 && filereadable(skeletonFile)
         let l:snippet = join(readfile(skeletonFile), "\n")


### PR DESCRIPTION
Use the name of the file (tail) if no extension is available. An example is `Makefile` where no extension is used.
My skeleton with skeleten.Makefile will be used